### PR TITLE
http: translate basic authentication in url to authorization header

### DIFF
--- a/http/http_internal_test.go
+++ b/http/http_internal_test.go
@@ -96,6 +96,38 @@ func TestParseAddress(t *testing.T) {
 	}
 }
 
+func TestParseBasicAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		address    string
+		headers    map[string]string
+		expHeaders map[string]string
+		err        string
+	}{
+		{
+			name:       "Simple",
+			address:    "http://user:pass@foo.com",
+			expHeaders: map[string]string{"Authorization": "Basic dXNlcjpwYXNz"},
+		},
+		{
+			name:    "Invalid",
+			address: "http:// foo",
+			err:     "failed to parse address",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newHeaders, err := parseBasicAuth(test.address, test.headers)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expHeaders, newHeaders)
+			}
+		})
+	}
+}
+
 func mustParseURL(input string) *url.URL {
 	base, _, err := parseAddress(input)
 	if err != nil {

--- a/http/service.go
+++ b/http/service.go
@@ -15,8 +15,10 @@ package http
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -112,6 +114,11 @@ func New(ctx context.Context, params ...Parameter) (client.Service, error) {
 		}
 	}
 
+	extraHeaders, err := parseBasicAuth(parameters.address, parameters.extraHeaders)
+	if err != nil {
+		return nil, err
+	}
+
 	base, address, err := parseAddress(parameters.address)
 	if err != nil {
 		return nil, err
@@ -125,7 +132,7 @@ func New(ctx context.Context, params ...Parameter) (client.Service, error) {
 		timeout:             parameters.timeout,
 		userIndexChunkSize:  parameters.indexChunkSize,
 		userPubKeyChunkSize: parameters.pubKeyChunkSize,
-		extraHeaders:        parameters.extraHeaders,
+		extraHeaders:        extraHeaders,
 		enforceJSON:         parameters.enforceJSON,
 		pingSem:             semaphore.NewWeighted(1),
 		hooks:               parameters.hooks,
@@ -424,4 +431,24 @@ func parseAddress(address string) (*url.URL, *url.URL, error) {
 	}
 
 	return base, &baseAddress, nil
+}
+
+// parseBasicAuth translates Basic access authentication parameters in address into Authorization header
+// and returns a copy of headers with the added Authorization header
+func parseBasicAuth(address string, headers map[string]string) (map[string]string, error) {
+	url, err := url.Parse(address)
+	if err != nil {
+		return nil, errors.New("failed to parse address")
+	}
+	if url.User == nil {
+		return headers, nil
+	}
+
+	headersWithAuth := make(map[string]string, len(headers)+1)
+	maps.Copy(headersWithAuth, headers)
+
+	password, _ := url.User.Password()
+	headersWithAuth["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(url.User.Username()+":"+password))
+
+	return headersWithAuth, nil
 }

--- a/http/service.go
+++ b/http/service.go
@@ -436,19 +436,19 @@ func parseAddress(address string) (*url.URL, *url.URL, error) {
 // parseBasicAuth adds an HTTP Basic Authorization header to a copy of the provided headers map if the address contains credentials.
 // If no credentials are present, it returns the original headers.
 func parseBasicAuth(address string, headers map[string]string) (map[string]string, error) {
-	url, err := url.Parse(address)
+	parsedURL, err := url.Parse(address)
 	if err != nil {
 		return nil, errors.New("failed to parse address")
 	}
-	if url.User == nil {
+	if parsedURL.User == nil {
 		return headers, nil
 	}
 
 	headersWithAuth := make(map[string]string, len(headers)+1)
 	maps.Copy(headersWithAuth, headers)
 
-	password, _ := url.User.Password()
-	headersWithAuth["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(url.User.Username()+":"+password))
+	password, _ := parsedURL.User.Password()
+	headersWithAuth["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(parsedURL.User.Username()+":"+password))
 
 	return headersWithAuth, nil
 }

--- a/http/service.go
+++ b/http/service.go
@@ -433,8 +433,8 @@ func parseAddress(address string) (*url.URL, *url.URL, error) {
 	return base, &baseAddress, nil
 }
 
-// parseBasicAuth translates Basic access authentication parameters in address into Authorization header
-// and returns a copy of headers with the added Authorization header
+// parseBasicAuth adds an HTTP Basic Authorization header to a copy of the provided headers map if the address contains credentials.
+// If no credentials are present, it returns the original headers.
 func parseBasicAuth(address string, headers map[string]string) (map[string]string, error) {
 	url, err := url.Parse(address)
 	if err != nil {


### PR DESCRIPTION
When the URL contains basic authentication, such as `http://user:pass@foo.com`, create an equivalent `Authorization` header, according to [RFC 7617](https://www.rfc-editor.org/rfc/rfc7617), which will be sent in future requests.