### PR TITLE
http: add missing scheme to url

### DIFF
--- a/http/http_internal_test.go
+++ b/http/http_internal_test.go
@@ -105,6 +105,16 @@ func TestParseBasicAuth(t *testing.T) {
 		err        string
 	}{
 		{
+			name: "No Scheme",
+			address: "127.0.0.1:5051",
+			expHeaders: nil,
+		},
+		{
+			name: "With Scheme",
+			address: "http://127.0.0.1:5051",
+			expHeaders: nil,
+		},
+		{
 			name:       "Simple",
 			address:    "http://user:pass@foo.com",
 			expHeaders: map[string]string{"Authorization": "Basic dXNlcjpwYXNz"},

--- a/http/service.go
+++ b/http/service.go
@@ -436,9 +436,12 @@ func parseAddress(address string) (*url.URL, *url.URL, error) {
 // parseBasicAuth adds an HTTP Basic Authorization header to a copy of the provided headers map if the address contains credentials.
 // If no credentials are present, it returns the original headers.
 func parseBasicAuth(address string, headers map[string]string) (map[string]string, error) {
+	if !strings.HasPrefix(address, "http") {
+		address = fmt.Sprintf("http://%s", address)
+	}
 	parsedURL, err := url.Parse(address)
 	if err != nil {
-		return nil, errors.New("failed to parse address")
+		return nil, errors.Join(errors.New("invalid URL"), err)
 	}
 	if parsedURL.User == nil {
 		return headers, nil


### PR DESCRIPTION
When missing, add `http` scheme to URL.
