### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions"],
+  "packageRules": [{
+    "matchManagers": ["github-actions"],
+    "matchDepTypes": ["github-actions"],
+    "matchFileNames": [".github/workflows/**"],
+    "schedule": ["every weekend"],
+    "labels": ["renovate/github-actions"],
+    "groupName": "GitHub Actions updates"
+  }]
+}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,13 +14,13 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           cache: false
           go-version: '1.25.2'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: "latest"
           args: "--timeout=60m"

--- a/.github/workflows/revive.yml
+++ b/.github/workflows/revive.yml
@@ -12,9 +12,9 @@ jobs:
   revive:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           cache: false
           go-version: '1.25.2'
-      - uses: actions/checkout@v4
-      - uses: morphy2k/revive-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: morphy2k/revive-action@7b25e715309495d5c3cdef7caccb65ad9fa74ba3 # v2

--- a/.github/workflows/sync-rebase.yml
+++ b/.github/workflows/sync-rebase.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: master
 
@@ -24,7 +24,7 @@ jobs:
 
       - name: Sync upstream changes
         id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        uses: aormsby/Fork-Sync-With-Upstream-action@1090e365224fc834e7e1de521c417ded2d6fcb53 # v3.4.1
         with:
           target_sync_branch: master
           target_repo_token: ${{ secrets.OBOL_PLATFORM_PAT }}
@@ -38,7 +38,7 @@ jobs:
     if: needs.sync_latest_from_upstream.outputs.has_new_commits == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: obol
@@ -83,7 +83,7 @@ jobs:
 
       - name: Rebase failed error
         if: (contains(steps.rebase.outputs.RESULT, 'error:') || contains(steps.rebase.outputs.RESULT, 'fatal:')) && !contains(steps.rebase.outputs.RESULT, 'Merge conflict in')
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_CHANNEL: dev-stack-releases
           SLACK_COLOR: eb3d2c #red
@@ -94,7 +94,7 @@ jobs:
 
       - name: Rebase failed conflict
         if: contains(steps.rebase.outputs.RESULT, 'Merge conflict in')
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_CHANNEL: dev-stack-releases
           SLACK_COLOR: ecc926 #yellow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: master
 
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: obol
@@ -152,7 +152,7 @@ jobs:
 
       - name: Rebase failed error
         if: (contains(steps.rebase.outputs.RESULT, 'error:') || contains(steps.rebase.outputs.RESULT, 'fatal:')) && !contains(steps.rebase.outputs.RESULT, 'Merge conflict in')
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_CHANNEL: dev-stack-releases
           SLACK_COLOR: eb3d2c #red
@@ -163,7 +163,7 @@ jobs:
 
       - name: Rebase failed conflict
         if: contains(steps.rebase.outputs.RESULT, 'Merge conflict in')
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_CHANNEL: dev-stack-releases
           SLACK_COLOR: ecc926 #yellow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           cache: false
           go-version: '1.25.2'
-      - uses: actions/checkout@v4
-      - uses: n8maninger/action-golang-test@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: n8maninger/action-golang-test@aa292dc81b16d34406a9551e629e0cdca00d9418 # v2
         with:
           args: "-race;-timeout=30m"
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to commit SHAs for supply chain security
- Original version tags preserved as inline comments for maintainability
- Add Renovate configuration for automated GitHub Actions updates (weekend schedule)

## Changes
- All `uses: owner/action@tag` → `uses: owner/action@SHA # tag`
- New `.github/renovate.json` with GitHub Actions manager only

## Test plan
- [x] Verify CI workflows run successfully
- [x] Confirm no action versions changed, only pinning format