### PR TITLE
Add /eth/v2/node/version

### DIFF
--- a/api/nodeversionv2opts.go
+++ b/api/nodeversionv2opts.go
@@ -1,0 +1,19 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// NodeVersionV2Opts are the options for obtaining the structured node version.
+type NodeVersionV2Opts struct {
+	Common CommonOpts
+}

--- a/api/v1/clientversion.go
+++ b/api/v1/clientversion.go
@@ -1,0 +1,84 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ClientVersion uniquely identifies a client implementation and its version, mirroring the
+// Engine API client version structure.
+type ClientVersion struct {
+	Code    string `json:"code"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+type clientVersionJSON struct {
+	Code    string `json:"code"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (c *ClientVersion) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&clientVersionJSON{
+		Code:    c.Code,
+		Name:    c.Name,
+		Version: c.Version,
+		Commit:  c.Commit,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (c *ClientVersion) UnmarshalJSON(input []byte) error {
+	var data clientVersionJSON
+	if err := json.Unmarshal(input, &data); err != nil {
+		return errors.Wrap(err, "invalid JSON")
+	}
+
+	if data.Code == "" {
+		return errors.New("code missing")
+	}
+	if data.Name == "" {
+		return errors.New("name missing")
+	}
+	if data.Version == "" {
+		return errors.New("version missing")
+	}
+	if data.Commit == "" {
+		return errors.New("commit missing")
+	}
+
+	c.Code = data.Code
+	c.Name = data.Name
+	c.Version = data.Version
+	c.Commit = data.Commit
+
+	return nil
+}
+
+func (c *ClientVersion) String() string {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("ERR: %v", err)
+	}
+
+	return string(data)
+}

--- a/api/v1/clientversion_test.go
+++ b/api/v1/clientversion_test.go
@@ -1,0 +1,101 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+)
+
+func TestClientVersionJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		err   string
+	}{
+		{
+			name: "Empty",
+			err:  "unexpected end of JSON input",
+		},
+		{
+			name:  "JSONBad",
+			input: []byte("[]"),
+			err:   "invalid JSON: json: cannot unmarshal array into Go value of type v1.clientVersionJSON",
+		},
+		{
+			name:  "CodeMissing",
+			input: []byte(`{"name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"}`),
+			err:   "code missing",
+		},
+		{
+			name:  "CodeWrongType",
+			input: []byte(`{"code":true,"name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"}`),
+			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field clientVersionJSON.code of type string",
+		},
+		{
+			name:  "NameMissing",
+			input: []byte(`{"code":"LH","version":"v8.0.1","commit":"0xced49dd2"}`),
+			err:   "name missing",
+		},
+		{
+			name:  "NameWrongType",
+			input: []byte(`{"code":"LH","name":true,"version":"v8.0.1","commit":"0xced49dd2"}`),
+			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field clientVersionJSON.name of type string",
+		},
+		{
+			name:  "VersionMissing",
+			input: []byte(`{"code":"LH","name":"Lighthouse","commit":"0xced49dd2"}`),
+			err:   "version missing",
+		},
+		{
+			name:  "VersionWrongType",
+			input: []byte(`{"code":"LH","name":"Lighthouse","version":true,"commit":"0xced49dd2"}`),
+			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field clientVersionJSON.version of type string",
+		},
+		{
+			name:  "CommitMissing",
+			input: []byte(`{"code":"LH","name":"Lighthouse","version":"v8.0.1"}`),
+			err:   "commit missing",
+		},
+		{
+			name:  "CommitWrongType",
+			input: []byte(`{"code":"LH","name":"Lighthouse","version":"v8.0.1","commit":true}`),
+			err:   "invalid JSON: json: cannot unmarshal bool into Go struct field clientVersionJSON.commit of type string",
+		},
+		{
+			name:  "Good",
+			input: []byte(`{"code":"LH","name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var res api.ClientVersion
+			err := json.Unmarshal(test.input, &res)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				rt, err := json.Marshal(&res)
+				require.NoError(t, err)
+				assert.Equal(t, string(test.input), string(rt))
+				assert.Equal(t, string(rt), res.String())
+			}
+		})
+	}
+}

--- a/api/v1/nodeversionv2.go
+++ b/api/v1/nodeversionv2.go
@@ -1,0 +1,67 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// NodeVersionV2 contains structured version information for the beacon node and, when available,
+// its attached execution client.
+type NodeVersionV2 struct {
+	BeaconNode      *ClientVersion `json:"beacon_node"`
+	ExecutionClient *ClientVersion `json:"execution_client,omitempty"`
+}
+
+type nodeVersionV2JSON struct {
+	BeaconNode      *ClientVersion `json:"beacon_node"`
+	ExecutionClient *ClientVersion `json:"execution_client,omitempty"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (n *NodeVersionV2) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&nodeVersionV2JSON{
+		BeaconNode:      n.BeaconNode,
+		ExecutionClient: n.ExecutionClient,
+	})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (n *NodeVersionV2) UnmarshalJSON(input []byte) error {
+	var data nodeVersionV2JSON
+	if err := json.Unmarshal(input, &data); err != nil {
+		return errors.Wrap(err, "invalid JSON")
+	}
+
+	if data.BeaconNode == nil {
+		return errors.New("beacon_node missing")
+	}
+
+	n.BeaconNode = data.BeaconNode
+	n.ExecutionClient = data.ExecutionClient
+
+	return nil
+}
+
+func (n *NodeVersionV2) String() string {
+	data, err := json.Marshal(n)
+	if err != nil {
+		return fmt.Sprintf("ERR: %v", err)
+	}
+
+	return string(data)
+}

--- a/api/v1/nodeversionv2_test.go
+++ b/api/v1/nodeversionv2_test.go
@@ -1,0 +1,85 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	api "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+)
+
+func TestNodeVersionV2JSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		err   string
+	}{
+		{
+			name: "Empty",
+			err:  "unexpected end of JSON input",
+		},
+		{
+			name:  "JSONBad",
+			input: []byte("[]"),
+			err:   "invalid JSON: json: cannot unmarshal array into Go value of type v1.nodeVersionV2JSON",
+		},
+		{
+			name:  "BeaconNodeMissing",
+			input: []byte(`{}`),
+			err:   "beacon_node missing",
+		},
+		{
+			name:  "BeaconNodeWrongType",
+			input: []byte(`{"beacon_node":true}`),
+			err:   "invalid JSON: invalid JSON: json: cannot unmarshal bool into Go value of type v1.clientVersionJSON",
+		},
+		{
+			name:  "BeaconNodeInvalid",
+			input: []byte(`{"beacon_node":{"name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"}}`),
+			err:   "invalid JSON: code missing",
+		},
+		{
+			name:  "ExecutionClientInvalid",
+			input: []byte(`{"beacon_node":{"code":"LH","name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"},"execution_client":{"code":"NM","name":"Nethermind","commit":"0xc066aee2"}}`),
+			err:   "invalid JSON: version missing",
+		},
+		{
+			name:  "BeaconNodeOnly",
+			input: []byte(`{"beacon_node":{"code":"LH","name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"}}`),
+		},
+		{
+			name:  "Full",
+			input: []byte(`{"beacon_node":{"code":"LH","name":"Lighthouse","version":"v8.0.1","commit":"0xced49dd2"},"execution_client":{"code":"NM","name":"Nethermind","version":"v1.35.8","commit":"0xc066aee2"}}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var res api.NodeVersionV2
+			err := json.Unmarshal(test.input, &res)
+			if test.err != "" {
+				require.EqualError(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+				rt, err := json.Marshal(&res)
+				require.NoError(t, err)
+				assert.Equal(t, string(test.input), string(rt))
+				assert.Equal(t, string(rt), res.String())
+			}
+		})
+	}
+}

--- a/http/nodeversionv2.go
+++ b/http/nodeversionv2.go
@@ -1,0 +1,81 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"bytes"
+	"context"
+
+	client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+)
+
+// NodeVersionV2 provides structured version information for the beacon node and, when available,
+// its attached execution client.
+func (s *Service) NodeVersionV2(ctx context.Context,
+	opts *api.NodeVersionV2Opts,
+) (
+	*api.Response[*apiv1.NodeVersionV2],
+	error,
+) {
+	// Carry this out without a connection check, as it is called when activating a client.
+	if opts == nil {
+		return nil, client.ErrNoOptions
+	}
+
+	s.nodeVersionV2Mutex.RLock()
+
+	if s.nodeVersionV2 != nil {
+		defer s.nodeVersionV2Mutex.RUnlock()
+
+		return &api.Response[*apiv1.NodeVersionV2]{
+			Data:     s.nodeVersionV2,
+			Metadata: make(map[string]any),
+		}, nil
+	}
+
+	s.nodeVersionV2Mutex.RUnlock()
+
+	s.nodeVersionV2Mutex.Lock()
+	defer s.nodeVersionV2Mutex.Unlock()
+
+	if s.nodeVersionV2 != nil {
+		// Someone else fetched this whilst we were waiting for the lock.
+		return &api.Response[*apiv1.NodeVersionV2]{
+			Data:     s.nodeVersionV2,
+			Metadata: make(map[string]any),
+		}, nil
+	}
+
+	// Up to us to fetch the information.
+	endpoint := "/eth/v2/node/version"
+
+	httpResponse, err := s.get(ctx, endpoint, "", &opts.Common, false)
+	if err != nil {
+		return nil, err
+	}
+
+	data, metadata, err := decodeJSONResponse(bytes.NewReader(httpResponse.body), apiv1.NodeVersionV2{})
+	if err != nil {
+		return nil, err
+	}
+
+	s.nodeVersionV2 = &data
+
+	return &api.Response[*apiv1.NodeVersionV2]{
+		Metadata: metadata,
+		Data:     &data,
+	}, nil
+}

--- a/http/nodeversionv2_test.go
+++ b/http/nodeversionv2_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http_test
+
+import (
+	"context"
+	"testing"
+
+	client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeVersionV2(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "Good",
+		},
+	}
+
+	service := testService(ctx, t).(client.Service)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := service.(client.NodeVersionV2Provider).NodeVersionV2(ctx, &api.NodeVersionV2Opts{})
+			require.NoError(t, err)
+			require.NotNil(t, response)
+			require.NotNil(t, response.Data)
+			require.NotNil(t, response.Data.BeaconNode)
+		})
+	}
+}

--- a/http/service.go
+++ b/http/service.go
@@ -58,6 +58,8 @@ type Service struct {
 	forkScheduleMutex    sync.RWMutex
 	nodeVersion          string
 	nodeVersionMutex     sync.RWMutex
+	nodeVersionV2        *apiv1.NodeVersionV2
+	nodeVersionV2Mutex   sync.RWMutex
 
 	// User-specified chunk sizes.
 	userIndexChunkSize  int
@@ -352,6 +354,9 @@ func (s *Service) clearStaticValues() {
 	s.nodeVersionMutex.Lock()
 	s.nodeVersion = ""
 	s.nodeVersionMutex.Unlock()
+	s.nodeVersionV2Mutex.Lock()
+	s.nodeVersionV2 = nil
+	s.nodeVersionV2Mutex.Unlock()
 }
 
 // checkDVT checks if connected to DVT middleware and sets

--- a/mock/nodeversionv2.go
+++ b/mock/nodeversionv2.go
@@ -1,0 +1,46 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+)
+
+// NodeVersionV2 returns structured version information for the beacon node and, when available,
+// its attached execution client.
+func (s *Service) NodeVersionV2(ctx context.Context,
+	opts *api.NodeVersionV2Opts,
+) (
+	*api.Response[*apiv1.NodeVersionV2],
+	error,
+) {
+	if s.NodeVersionV2Func != nil {
+		return s.NodeVersionV2Func(ctx, opts)
+	}
+
+	return &api.Response[*apiv1.NodeVersionV2]{
+		Data: &apiv1.NodeVersionV2{
+			BeaconNode: &apiv1.ClientVersion{
+				Code:    "MK",
+				Name:    "mock",
+				Version: s.nodeVersion,
+				Commit:  "0x00000000",
+			},
+		},
+		Metadata: make(map[string]any),
+	}, nil
+}

--- a/mock/service.go
+++ b/mock/service.go
@@ -73,6 +73,7 @@ type Service struct {
 	NodePeerCountFunc             func(context.Context, *api.NodePeerCountOpts) (*api.Response[*apiv1.PeerCount], error)
 	NodeSyncingFunc               func(context.Context, *api.NodeSyncingOpts) (*api.Response[*apiv1.SyncState], error)
 	NodeVersionFunc               func(context.Context, *api.NodeVersionOpts) (*api.Response[string], error)
+	NodeVersionV2Func             func(context.Context, *api.NodeVersionV2Opts) (*api.Response[*apiv1.NodeVersionV2], error)
 	PendingDepositsFunc           func(context.Context, *api.PendingDepositsOpts) (*api.Response[[]*electra.PendingDeposit], error)
 	PendingConsolidationsFunc     func(context.Context, *api.PendingConsolidationsOpts) (*api.Response[[]*electra.PendingConsolidation], error)
 	PendingPartialWithdrawalsFunc func(context.Context, *api.PendingPartialWithdrawalsOpts) (*api.Response[[]*electra.PendingPartialWithdrawal], error)

--- a/multi/nodeversionv2.go
+++ b/multi/nodeversionv2.go
@@ -1,0 +1,50 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multi
+
+import (
+	"context"
+
+	consensusclient "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+)
+
+// NodeVersionV2 provides structured version information for the beacon node and, when available,
+// its attached execution client.
+func (s *Service) NodeVersionV2(ctx context.Context,
+	opts *api.NodeVersionV2Opts,
+) (
+	*api.Response[*apiv1.NodeVersionV2],
+	error,
+) {
+	res, err := s.doCall(ctx, func(ctx context.Context, client consensusclient.Service) (any, error) {
+		aggregate, err := client.(consensusclient.NodeVersionV2Provider).NodeVersionV2(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		return aggregate, nil
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response, isResponse := res.(*api.Response[*apiv1.NodeVersionV2])
+	if !isResponse {
+		return nil, ErrIncorrectType
+	}
+
+	return response, nil
+}

--- a/multi/nodeversionv2_test.go
+++ b/multi/nodeversionv2_test.go
@@ -1,0 +1,62 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multi_test
+
+import (
+	"context"
+	"testing"
+
+	consensusclient "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/attestantio/go-eth2-client/mock"
+	"github.com/attestantio/go-eth2-client/multi"
+	"github.com/attestantio/go-eth2-client/testclients"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeVersionV2(t *testing.T) {
+	ctx := context.Background()
+
+	client1, err := mock.New(ctx, mock.WithName("mock 1"))
+	require.NoError(t, err)
+	erroringClient1, err := testclients.NewErroring(ctx, 0.1, client1)
+	require.NoError(t, err)
+	client2, err := mock.New(ctx, mock.WithName("mock 2"))
+	require.NoError(t, err)
+	erroringClient2, err := testclients.NewErroring(ctx, 0.1, client2)
+	require.NoError(t, err)
+	client3, err := mock.New(ctx, mock.WithName("mock 3"))
+	require.NoError(t, err)
+
+	multiClient, err := multi.New(ctx,
+		multi.WithLogLevel(zerolog.Disabled),
+		multi.WithClients([]consensusclient.Service{
+			erroringClient1,
+			erroringClient2,
+			client3,
+		}),
+	)
+	require.NoError(t, err)
+
+	for i := 0; i < 128; i++ {
+		res, err := multiClient.(consensusclient.NodeVersionV2Provider).NodeVersionV2(ctx, &api.NodeVersionV2Opts{})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.NotNil(t, res.Data)
+		require.NotNil(t, res.Data.BeaconNode)
+	}
+	// At this point we expect mock 3 to be in active (unless probability hates us).
+	require.Equal(t, "mock 3", multiClient.Address())
+}

--- a/service.go
+++ b/service.go
@@ -593,6 +593,18 @@ type NodeVersionProvider interface {
 	)
 }
 
+// NodeVersionV2Provider is the interface for providing the structured node version.
+type NodeVersionV2Provider interface {
+	// NodeVersionV2 returns structured version information for the beacon node and, when available,
+	// its attached execution client.
+	NodeVersionV2(ctx context.Context,
+		opts *api.NodeVersionV2Opts,
+	) (
+		*api.Response[*apiv1.NodeVersionV2],
+		error,
+	)
+}
+
 // ProposalPreparationsSubmitter is the interface for submitting proposal preparations.
 type ProposalPreparationsSubmitter interface {
 	// SubmitProposalPreparations provides the beacon node with information required if a proposal for the given validators

--- a/testclients/erroring.go
+++ b/testclients/erroring.go
@@ -163,6 +163,26 @@ func (s *Erroring) NodeVersion(ctx context.Context,
 	return next.NodeVersion(ctx, opts)
 }
 
+// NodeVersionV2 returns structured version information for the beacon node and, when available,
+// its attached execution client.
+func (s *Erroring) NodeVersionV2(ctx context.Context,
+	opts *api.NodeVersionV2Opts,
+) (
+	*api.Response[*apiv1.NodeVersionV2],
+	error,
+) {
+	if err := s.maybeError(ctx); err != nil {
+		return nil, err
+	}
+
+	next, isNext := s.next.(consensusclient.NodeVersionV2Provider)
+	if !isNext {
+		return nil, fmt.Errorf("%s@%s does not support this call", s.next.Name(), s.next.Address())
+	}
+
+	return next.NodeVersionV2(ctx, opts)
+}
+
 // SlotDuration provides the duration of a slot of the chain.
 //
 // Deprecated: use Spec().

--- a/testclients/sleepy.go
+++ b/testclients/sleepy.go
@@ -152,6 +152,24 @@ func (s *Sleepy) NodeVersion(ctx context.Context,
 	return next.NodeVersion(ctx, opts)
 }
 
+// NodeVersionV2 returns structured version information for the beacon node and, when available,
+// its attached execution client.
+func (s *Sleepy) NodeVersionV2(ctx context.Context,
+	opts *api.NodeVersionV2Opts,
+) (
+	*api.Response[*apiv1.NodeVersionV2],
+	error,
+) {
+	s.sleep(ctx)
+
+	next, isNext := s.next.(consensusclient.NodeVersionV2Provider)
+	if !isNext {
+		return nil, errors.New("next does not support this call")
+	}
+
+	return next.NodeVersionV2(ctx, opts)
+}
+
 // SlotDuration provides the duration of a slot of the chain.
 //
 // Deprecated: use Spec().


### PR DESCRIPTION
As per the spec
https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getNodeVersionV2
Even though it's in `dev` some clients already have it implemented and we'd find it useful on Obol's side.